### PR TITLE
Issue#31, requested by Masako.

### DIFF
--- a/language_models/ja/metadata.csv
+++ b/language_models/ja/metadata.csv
@@ -14,5 +14,6 @@ NonRelevantsToMergeMax;50
 /*
 /* https://github.com/intersystems/iknow/issues/31
 /* Furigana Handling made flexible: "on"=handle as originally implemented (default), "off"=no special treatment
+/*  a few refinements have been added recently : If the furigana text is ALL Katakana, or ALL Numeric, it will be handled normally.
 /*
 FuriganaHandling;on


### PR DESCRIPTION
if detected Furigana is ALL Katakana, or ALL Numeric, it will be handled normally.

We keep the "FuriganaHandling;on" switch, if set to "off", Furigana detection will be disabled.