### PR TITLE
CI workflow: adding apt-get update step

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,7 +70,9 @@ jobs:
             ~/ccache
             ~/pipcache
       - name: install dependencies
-        run: sudo apt-get install -y qemu-user-static binfmt-support
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static binfmt-support
       - name: build
         run: docker run --rm -e CCACHE_DIR=/ccache -e PIP_CACHE_DIR=/pipcache -e CCACHE_MAXSIZE=350M -e ICU_URL -e CYTHON_VERSION -v ~/ccache:/ccache -v ~/pipcache:/pipcache -v $GITHUB_WORKSPACE:/iknow quay.io/pypa/manylinux2014_aarch64:$MANYLINUX2014_AARCH64_TAG /iknow/.github/workflows/build_manylinux.sh
       - name: upload wheel artifact
@@ -99,7 +101,9 @@ jobs:
             ~/ccache
             ~/pipcache
       - name: install dependencies
-        run: sudo apt-get install -y qemu-user-static binfmt-support
+        run:  |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static binfmt-support
       - name: build
         run: docker run --rm -e CCACHE_DIR=/ccache -e PIP_CACHE_DIR=/pipcache -e CCACHE_MAXSIZE=350M -e ICU_URL -e CYTHON_VERSION -v ~/ccache:/ccache -v ~/pipcache:/pipcache -v $GITHUB_WORKSPACE:/iknow quay.io/pypa/manylinux2014_ppc64le:$MANYLINUX2014_PPC64LE_TAG /iknow/.github/workflows/build_manylinux.sh
       - name: upload wheel artifact


### PR DESCRIPTION
Looking at the failures in the CI workflow, it looks like we might just have to do an `apt-get update` to avoid those 404s in the `install dependencies` step. I'm not 100% sure (and maybe you wanted to avoid as blunt a step), but it looks like it manages to get past the failures when running the CI workflow on my own fork.