### PR TITLE
[autoupdate] Update Python for Windows: 3.9.0→3.9.1

### DIFF
--- a/.github/workflows/dependencies.sh
+++ b/.github/workflows/dependencies.sh
@@ -12,7 +12,7 @@ set -euxo pipefail
 ICU_NAME="ICU 68.1"
 ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-68-1/icu4c-68_1-Win64-MSVC2019.zip
 ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-68-1/icu4c-68_1-src.zip
-PYVERSIONS_WIN="3.5.4 3.6.8 3.7.9 3.8.6 3.9.0"
+PYVERSIONS_WIN="3.5.4 3.6.8 3.7.9 3.8.6 3.9.1"
 PYVERSIONS_OSX="3.5.10 3.6.12 3.7.9 3.8.6 3.9.0"
 PYENV_TOOL_VERSION=1.2.21
 BUILDCACHE_NAME="Release v0.23.0"


### PR DESCRIPTION
A new version of Python for Windows is available.

- 3.9.0 can be updated to 3.9.1

For details of all Python releases, see https://www.nuget.org/packages/python.

*I am a bot, and this action was performed automatically.*