### PR TITLE
[autoupdate] Update ICU from "ICU 68.1" to "ICU 68.2"

### DIFF
--- a/.github/workflows/dependencies.sh
+++ b/.github/workflows/dependencies.sh
@@ -9,9 +9,9 @@ set -euxo pipefail
 # change .github/workflows/updatelib.py.
 
 # START DEPENDENCY-AUTOUPDATE SECTION
-ICU_NAME="ICU 68.1"
-ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-68-1/icu4c-68_1-Win64-MSVC2019.zip
-ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-68-1/icu4c-68_1-src.zip
+ICU_NAME="ICU 68.2"
+ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-68-2/icu4c-68_2-Win64-MSVC2019.zip
+ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-68-2/icu4c-68_2-src.zip
 PYVERSIONS_WIN="3.5.4 3.6.8 3.7.9 3.8.6 3.9.1"
 PYVERSIONS_OSX="3.5.10 3.6.12 3.7.9 3.8.6 3.9.0"
 PYENV_TOOL_VERSION=1.2.21


### PR DESCRIPTION
As of 2020-12-17T00:40:49Z, a new version of ICU has been released.

Release Information (sourced from https://github.com/unicode-org/icu/releases/tag/release-68-2)
<blockquote>

We are pleased to announce the release of Unicode® ICU 68.

ICU 68 updates to [CLDR 38](http://cldr.unicode.org/index/downloads/cldr-38) locale data with many additions and corrections. ICU 68 brings major improvements and API additions for measurement unit formatting, implements locale ID canonicalization conformant with CLDR, and includes many other bug fixes and enhancements.

This 68.2 maintenance release adds some bug fixes from CLDR 38.1 and for some issues in the ICU code.

For details please see http://site.icu-project.org/download/68

The API reference documents are published at the following location: https://unicode-org.github.io/icu-docs/
(No changes/updates for 68.2.)

*Note: The prebuilt WinARM64 binaries below should be considered alpha/experimental.*
</blockquote>

*I am a bot, and this action was performed automatically.*