### PR TITLE
[autoupdate] Update Python for Windows: 3.8.7→3.8.8, 3.9.1→3.9.2

### DIFF
--- a/.github/workflows/dependencies.sh
+++ b/.github/workflows/dependencies.sh
@@ -12,7 +12,7 @@ set -euxo pipefail
 ICU_NAME="ICU 68.2"
 ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-68-2/icu4c-68_2-Win64-MSVC2019.zip
 ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-68-2/icu4c-68_2-src.zip
-PYVERSIONS_WIN="3.6.8 3.7.9 3.8.7 3.9.1"
+PYVERSIONS_WIN="3.6.8 3.7.9 3.8.8 3.9.2"
 PYVERSIONS_OSX="3.6.13 3.7.10 3.8.7 3.9.1"
 BUILDCACHE_NAME="Release v0.25.3"
 BUILDCACHE_URL_WIN=https://github.com/mbitsnbites/buildcache/releases/download/v0.25.3/buildcache-win-msvc.zip


### PR DESCRIPTION
A new version of Python for Windows is available.

- 3.8.7 can be updated to 3.8.8
- 3.9.1 can be updated to 3.9.2

For details of all Python releases, see https://www.nuget.org/packages/python.

*I am a bot, and this action was performed automatically.*