### PR TITLE
[autoupdate] Update Python for Windows: 3.9.5→3.9.6

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -12,7 +12,7 @@ set -euxo pipefail
 ICU_NAME="ICU 69.1"
 ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-Win64-MSVC2019.zip
 ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-src.zip
-PYVERSIONS_WIN="3.6.8 3.7.9 3.8.10 3.9.5"
+PYVERSIONS_WIN="3.6.8 3.7.9 3.8.10 3.9.6"
 PYVERSIONS_OSX="3.6.13 3.7.10 3.8.10 3.9.5"
 BUILDCACHE_NAME="Release v0.27.0"
 BUILDCACHE_URL_WIN=https://github.com/mbitsnbites/buildcache/releases/download/v0.27.0/buildcache-windows.zip


### PR DESCRIPTION
A new version of Python for Windows is available.

- 3.9.5 can be updated to 3.9.6

For details of all Python releases, see https://www.nuget.org/packages/python.

*I am a bot, and this action was performed automatically.*