### PR TITLE
[autoupdate] Update Python for Windows: 3.9.6→3.9.7

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -12,7 +12,7 @@ set -euxo pipefail
 ICU_NAME="ICU 69.1"
 ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-Win64-MSVC2019.zip
 ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-src.zip
-PYVERSIONS_WIN="3.6.8 3.7.9 3.8.10 3.9.6"
+PYVERSIONS_WIN="3.6.8 3.7.9 3.8.10 3.9.7"
 PYVERSIONS_OSX="3.6.14 3.7.11 3.8.11 3.9.6"
 BUILDCACHE_NAME="Release v0.27.1"
 BUILDCACHE_URL_WIN=https://github.com/mbitsnbites/buildcache/releases/download/v0.27.1/buildcache-windows.zip


### PR DESCRIPTION
A new version of Python for Windows is available.

- 3.9.6 can be updated to 3.9.7

For details of all Python releases, see https://www.nuget.org/packages/python.

*I am a bot, and this action was performed automatically.*