### PR TITLE
[autoupdate] Update JSON for Modern C++ from "3.10.3" to "3.10.4"

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -13,8 +13,8 @@ set -euxo pipefail
 ICU_NAME="ICU 69.1"
 ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-Win64-MSVC2019.zip
 ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-src.zip
-JSON_VERSION=3.10.3
-JSON_URL=https://github.com/nlohmann/json/releases/download/v3.10.3/include.zip
+JSON_VERSION=3.10.4
+JSON_URL=https://github.com/nlohmann/json/releases/download/v3.10.4/include.zip
 PYVERSIONS_WIN="3.6.8 3.7.9 3.8.10 3.9.7 3.10.0"
 PYVERSIONS_OSX="3.6.14 3.7.12 3.8.12 3.9.7 3.10.0"
 BUILDCACHE_NAME="Release v0.27.1"


### PR DESCRIPTION
As of 2021-10-16T12:49:30Z, a new version of JSON for Modern C++ has been released.

Release Information (sourced from https://github.com/nlohmann/json/releases/tag/v3.10.4)
<blockquote>

Release date: 2021-10-16
SHA-256: c9ac7589260f36ea7016d4d51a6c95809803298c7caec9f55830a0214c5f9140 (json.hpp), 62c585468054e2d8e7c2759c0d990fd339d13be988577699366fe195162d16cb (include.zip)

### Summary

This release fixes two bugs introduced in release 3.10.0 and fixes the conversion of `std::filesystem::path`. All changes are backward-compatible.

:moneybag: Note you can **support this project** via [GitHub sponsors](https://github.com/sponsors/nlohmann) or [PayPal](http://paypal.me/nlohmann).

### :bug: Bug Fixes

- Fix regression bug introduced in release 3.10.0 which broke compilation for types with an explicit default constructor with default arguments. #3077 #3079
- Fix regression bug introduced in release 3.10.0 which treated the return values of `std::find` and `std::remove` as pointers which could break compilation. #3081 #3082
- Fix converting `std::filesystem::path` to JSON. Before release 3.10.3, such a conversion would trigger a stack overflow. Release 3.10.3 then further broke compilation on Windows. #3070 #3073

### :fire: Deprecated functions

Passing iterator pairs or pointer/length pairs to parsing functions (`basic_json::parse`, `basic_json::accept`, `basic_json::sax_parse`, `basic_json::from_cbor`, `basic_json::from_msgpack`, `basic_json::from_ubjson`, `basic_json::from_bson`) via initializer lists is deprecated. Instead, pass two iterators; for instance, call `basic_json::from_cbor(ptr, ptr+len)` instead of `basic_json::from_cbor({ptr, len})`.

The following functions have been deprecated in earlier versions and will be removed in the next major version (i.e., 4.0.0):

- Function [`iterator_wrapper`](https://nlohmann.github.io/json/doxygen/classnlohmann_1_1basic__json_a0a8051760196ac813fd5eb3c8d5a2976.html#a0a8051760196ac813fd5eb3c8d5a2976) are deprecated. Please use the member function [`items()`](https://nlohmann.github.io/json/doxygen/classnlohmann_1_1basic__json_a5961446010dfc494e0c247b4e9026977.html#a5961446010dfc494e0c247b4e9026977) instead.
- Functions [`friend std::istream& operator<<(basic_json&, std::istream&)`](https://nlohmann.github.io/json/doxygen/classnlohmann_1_1basic__json_a60ca396028b8d9714c6e10efbf475af6.html#a60ca396028b8d9714c6e10efbf475af6) and [`friend std::ostream& operator>>(const basic_json&, std::ostream&)`](https://nlohmann.github.io/json/doxygen/classnlohmann_1_1basic__json_a34d6a60dd99e9f33b8273a1c8db5669b.html#a34d6a60dd99e9f33b8273a1c8db5669b) are deprecated. Please use [`friend std::istream&  operator>>(std::istream&, basic_json&)`](https://nlohmann.github.io/json/doxygen/classnlohmann_1_1basic__json_aaf363408931d76472ded14017e59c9e8.html#aaf363408931d76472ded14017e59c9e8) and [`friend operator<<(std::ostream&, const basic_json&)`](https://nlohmann.github.io/json/doxygen/classnlohmann_1_1basic__json_a5e34c5435e557d0bf666bd7311211405.html#a5e34c5435e557d0bf666bd7311211405) instead.

All deprecations are annotated with [`HEDLEY_DEPRECATED_FOR`](https://nemequ.github.io/hedley/api-reference.html#HEDLEY_DEPRECATED_FOR) to report which function to use instead.

</blockquote>

*I am a bot, and this action was performed automatically.*