### PR TITLE
[autoupdate] Update ICU from "ICU 69.1" to "ICU 70.1"

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -10,9 +10,9 @@ set -euxo pipefail
 # in actions/updatelib.py.
 
 # START DEPENDENCY-AUTOUPDATE SECTION
-ICU_NAME="ICU 69.1"
-ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-Win64-MSVC2019.zip
-ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-src.zip
+ICU_NAME="ICU 70.1"
+ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-70-1/icu4c-70_1-Win64-MSVC2019.zip
+ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-70-1/icu4c-70_1-src.zip
 JSON_VERSION=3.10.4
 JSON_URL=https://github.com/nlohmann/json/releases/download/v3.10.4/include.zip
 PYVERSIONS_WIN="3.6.8 3.7.9 3.8.10 3.9.7 3.10.0"


### PR DESCRIPTION
As of 2021-10-28T00:27:33Z, a new version of ICU has been released.

Release Information (sourced from https://github.com/unicode-org/icu/releases/tag/release-70-1)
<blockquote>

We are pleased to announce the release of Unicode® ICU 70.

ICU 70 updates to [Unicode 14](http://blog.unicode.org/2021/09/announcing-unicode-standard-version-140.html), including new characters, scripts, emoji, and corresponding API constants. ICU 70 adds support for emoji properties of strings. It also updates to [CLDR 40](http://cldr.unicode.org/index/downloads/cldr-40) locale data with many additions and corrections. ICU 70 also includes many other bug fixes and enhancements, especially for measurement unit formatting, and it can now be built and used with C++20 compilers.

For details, please see https://icu.unicode.org/download/70.
Note: Our website has moved. Please adjust your bookmarks.

The API reference documents are published at the following location: https://unicode-org.github.io/icu-docs/

*Note: The prebuilt WinARM64 binaries below should be considered alpha/experimental.*
</blockquote>

*I am a bot, and this action was performed automatically.*