### PR TITLE
[autoupdate] Update JSON for Modern C++ from "3.10.5" to "3.11.1"

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -13,8 +13,8 @@ set -euxo pipefail
 ICU_NAME="ICU 71.1"
 ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-71-1/icu4c-71_1-Win64-MSVC2019.zip
 ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-71-1/icu4c-71_1-src.zip
-JSON_VERSION=3.10.5
-JSON_URL=https://github.com/nlohmann/json/releases/download/v3.10.5/include.zip
+JSON_VERSION=3.11.1
+JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.1/include.zip
 PYVERSIONS_WIN="3.6.8 3.7.9 3.8.10 3.9.13 3.10.6"
 PYVERSIONS_OSX="3.6.15 3.7.13 3.8.13 3.9.13 3.10.5"
 BUILDCACHE_NAME="Release v0.27.6"


### PR DESCRIPTION
As of 2022-08-01T21:32:26Z, a new version of JSON for Modern C++ has been released.

Release Information (sourced from https://github.com/nlohmann/json/releases/tag/v3.11.1)
<blockquote>

Release date: 2022-08-01
SHA-256: 9279dc616aac67efce68967f118051b50236612b90572e059783d368bd78687e (json.hpp), 9c15ca7806f863872452bfbc85fee6d1c9868117e3ea5e00a204ae961a2e1ae7 (include.zip), e6dd39f8f2da9cab11de2212acdd40b1cc1aafbe09da8c92933b911d19da3302 (json.tar.xz)

### Known issues

- #3652 Regression: call to member function 'value' is ambiguous
- #3654 Regression: no match for 'operator!=' comparing json_pointer and const char */string_t
- #3655 Regression: .value<size_t> is compilation error

### Summary

[Version 3.11.0](https://github.com/nlohmann/json/releases/tag/v3.11.0) moved the user-defined string literals (UDL) into namespace `nlohmann::literals::json_literals` (see [documentation](https://json.nlohmann.me/api/macros/json_use_global_udls/)). Unfortunately, this namespace was not imported to the global namespace by default which broke code. This release fixes this bug.

All changes are backward-compatible. See [release notes of version 3.11.0](https://github.com/nlohmann/json/releases/tag/v3.11.0) for more information on other features.

:moneybag: Note you can **support this project** via [GitHub sponsors](https://github.com/sponsors/nlohmann) or [PayPal](https://paypal.me/nlohmann).

### :bug: Bug fixes

- Set default value of [`JSON_USE_GLOBAL_UDLS`](https://json.nlohmann.me/api/macros/json_use_global_udls/) and the CMake options `JSON_GlobalUDLs` to `1` to import the user-defined string literals from the `nlohmann::literals::json_literals` namespace into the global namespace by default.
  - #3644
  - #3645
  - #3646

</blockquote>

*I am a bot, and this action was performed automatically.*