### PR TITLE
[autoupdate] Update JSON for Modern C++ from "3.11.1" to "3.11.2"

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -13,8 +13,8 @@ set -euxo pipefail
 ICU_NAME="ICU 71.1"
 ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-71-1/icu4c-71_1-Win64-MSVC2019.zip
 ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-71-1/icu4c-71_1-src.zip
-JSON_VERSION=3.11.1
-JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.1/include.zip
+JSON_VERSION=3.11.2
+JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip
 PYVERSIONS_WIN="3.6.8 3.7.9 3.8.10 3.9.13 3.10.6"
 PYVERSIONS_OSX="3.6.15 3.7.13 3.8.13 3.9.13 3.10.6"
 BUILDCACHE_NAME="Release v0.27.6"


### PR DESCRIPTION
As of 2022-08-12T13:06:34Z, a new version of JSON for Modern C++ has been released.

Release Information (sourced from https://github.com/nlohmann/json/releases/tag/v3.11.2)
<blockquote>

Release date: 2022-08-12
SHA-256: 665fa14b8af3837966949e8eb0052d583e2ac105d3438baba9951785512cf921 (json.hpp), e5c7a9f49a16814be27e4ed0ee900ecd0092bfb7dbfca65b5a421b774dccaaed (include.zip), 8c4b26bf4b422252e13f332bc5e388ec0ab5c3443d24399acb675e68278d341f (json.tar.xz)

### Summary

This release fixes some bugs found in the [3.11.1](https://github.com/nlohmann/json/releases/tag/v3.11.1) release. Furthermore, the []((https://json.nlohmann.me/features/namespace/)) of the library has been re-structured.

All changes are backward-compatible.

:moneybag: Note you can **support this project** via [GitHub sponsors](https://github.com/sponsors/nlohmann) or [PayPal](https://paypal.me/nlohmann).

### :bug: Bug Fixes

- Fix the [`value`](https://json.nlohmann.me/api/basic_json/value/) function which was broken for strings, size types, and `nullptr` in release 3.11.0. #3652 #3655 #3663
- Fix the `json_fwd.hpp` header to be self-contained and add it to the single-header release. #3656 #3679 #3687
- Fix regression that broke using [`json_pointer`](https://json.nlohmann.me/api/json_pointer/) as key in associative containers. #3680 #3685
- Add missing constraint to deprecated JSON Pointer overloads of [`contains`](https://json.nlohmann.me/api/basic_json/contains/) and [`at`](https://json.nlohmann.me/api/basic_json/at/). #3658 #3681 
- Fix comparison between [`json_pointer`](https://json.nlohmann.me/api/json_pointer/) and strings with `==` and `!=`. These comparisons worked in 3.10.5, but were broken in 3.11.0 and 3.11.1. #3654 #3664
- Fix `to_json` conversion of `std::vector<bool>::reference` and `std::vector<bool>::const_reference` for STLs where these are the same as `basic_json::boolean_t&` and `basic_json::boolean_t`, respectively. #3677 #3678

### :zap: Improvements

- Restructure inline namespace and allow version component to be disabled. See [documentation](https://json.nlohmann.me/features/namespace/). #3683 #3696 #3697 #3698
- Avoid heap allocations in [BJData](https://json.nlohmann.me/features/binary_formats/bjdata/) parser. #3637

### :hammer: Further Changes

#### Documentation

- Publish documentation on every push to `develop` branch. #3660 #3673
- Add missing examples for the [public API](https://json.nlohmann.me/api/basic_json/). #3672 #3686
- Fix typo in [`json_pointer`](https://json.nlohmann.me/api/json_pointer/) documentation. #3692

#### Community

- Add a badge for the [Discord chat](https://discord.gg/6mrGXKvX7y) to the README file. The goal of that additional communication channel beyond [the existing ones](https://github.com/nlohmann/json#support) is to quickly coordinate between the contributors. #3651
- Complete contributor list. #3662 #3670

#### CI

- Remove the `macos-10.15` image from the CI as it is removed by GitHub Actions. #3612 #3615 #3626
- Remove hardcoded paths in Ubuntu workflow. #3626
- Only trigger AppVeyor builds if relevant files have been changed. #3626
- Fix CodeQL warning. #3626
- Harmonize naming of GitHub Actions jobs. #3661
- Add labeler action to automatically add PR labels based on the changed files. #3671 #3674 #3675
- Lint API documentation in the CI. #3672
- Add local [LGTM](http://lgtm.com) configuration and suppress warnings on third-party scripts. #3643

### :fire: Deprecated functions

- This release deprecates comparing JSON Pointers with strings via [`operator==`](https://json.nlohmann.me/api/json_pointer/operator_eq/) and [`operator!=`](https://json.nlohmann.me/api/json_pointer/operator_ne/). To compare a [`json_pointer`](https://json.nlohmann.me/api/json_pointer/) `p` with a string `s`, convert `s` to a `json_pointer` first and use [`json_pointer::operator==`](https://json.nlohmann.me/api/json_pointer/operator_eq/) or [`json_pointer::operator!=`](https://json.nlohmann.me/api/json_pointer/operator_ne/). #3684

The following functions have been deprecated in earlier versions and will be removed in the next major version (i.e., 4.0.0):

- The function `iterator_wrapper` is deprecated. Please use the member function [`items()`](https://json.nlohmann.me/api/basic_json/items/) instead.
- Functions `friend std::istream& operator<<(basic_json&, std::istream&)` and `friend std::ostream& operator>>(const basic_json&, std::ostream&)` are deprecated. Please use [`friend std::istream&  operator>>(std::istream&, basic_json&)`](https://json.nlohmann.me/api/operator_gtgt/) and [`friend operator<<(std::ostream&, const basic_json&)`](https://json.nlohmann.me/api/operator_ltlt/) instead.
- Passing iterator pairs or pointer/length pairs to parsing functions (`basic_json::parse`, `basic_json::accept`, `basic_json::sax_parse`, `basic_json::from_cbor`, `basic_json::from_msgpack`, `basic_json::from_ubjson`, `basic_json::from_bson`) via initializer lists is deprecated. Instead, pass two iterators; for instance, call `basic_json::from_cbor(ptr, ptr+len)` instead of `basic_json::from_cbor({ptr, len})`.
- The implicit conversion from JSON Pointers to string ([`json_pointer::operator string_t`](https://json.nlohmann.me/api/json_pointer/operator_string_t)) is deprecated. Use [`json_pointer::to_string`](https://json.nlohmann.me/api/json_pointer/to_string/) instead.

All deprecations are annotated with [`HEDLEY_DEPRECATED_FOR`](https://nemequ.github.io/hedley/api-reference.html#HEDLEY_DEPRECATED_FOR) to report which function to use instead.

</blockquote>

*I am a bot, and this action was performed automatically.*