### PR TITLE
[autoupdate] Update ICU from "ICU 72.1" to "ICU 73.1"

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -10,9 +10,9 @@ set -euxo pipefail
 # in actions/updatelib.py.
 
 # START DEPENDENCY-AUTOUPDATE SECTION
-ICU_NAME="ICU 72.1"
-ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-72-1/icu4c-72_1-Win64-MSVC2019.zip
-ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-72-1/icu4c-72_1-src.tgz
+ICU_NAME="ICU 73.1"
+ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-73-1/icu4c-73_1-Win64-MSVC2019.zip
+ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-73-1/icu4c-73_1-src.tgz
 JSON_VERSION=3.11.2
 JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip
 PYVERSIONS_WIN="3.7.9 3.8.10 3.9.13 3.10.11 3.11.3"


### PR DESCRIPTION
As of 2023-04-12T23:52:46Z, a new version of ICU has been released.

Release Information (sourced from https://github.com/unicode-org/icu/releases/tag/release-73-1)
<blockquote>

We are pleased to announce the release of Unicode® ICU 73. It updates to [CLDR 43](https://blog.unicode.org/2023/04/the-unicode-cldr-v43-released.html) locale data with various additions and corrections.

ICU 73 improves Japanese and Korean short-text line breaking, reduces C++ memory use in date formatting, and promotes the Java person name formatter from tech preview to draft.

ICU 73 and CLDR 43 are minor releases, mostly focused on bug fixes and small enhancements. (The fall CLDR/ICU releases will update to Unicode 15.1 which is planned for September.)

ICU 73 updates to the time zone data version 2023c (2023-mar). Note that pre-1970 data for a number of time zones has been removed, as has been the case in the upstream [tzdata](https://www.iana.org/time-zones) release since 2021b.

For details, please see https://icu.unicode.org/download/73.

_Note: The prebuilt WinARM64 binaries below should be considered alpha/experimental._
</blockquote>

*I am a bot, and this action was performed automatically.*