### PR TITLE
[autoupdate] Update ICU from "ICU 73.1" to "ICU 73.2"

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -10,9 +10,9 @@ set -euxo pipefail
 # in actions/updatelib.py.
 
 # START DEPENDENCY-AUTOUPDATE SECTION
-ICU_NAME="ICU 73.1"
-ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-73-1/icu4c-73_1-Win64-MSVC2019.zip
-ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-73-1/icu4c-73_1-src.tgz
+ICU_NAME="ICU 73.2"
+ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-Win64-MSVC2019.zip
+ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-src.tgz
 JSON_VERSION=3.11.2
 JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip
 PYVERSIONS_WIN="3.7.9 3.8.10 3.9.13 3.10.11 3.11.4"


### PR DESCRIPTION
As of 2023-06-13T01:06:20Z, a new version of ICU has been released.

Release Information (sourced from https://github.com/unicode-org/icu/releases/tag/release-73-2)
<blockquote>

We are pleased to announce the release of Unicode® ICU 73.2. It updates to [CLDR 43.1](https://cldr.unicode.org/index/downloads/cldr-43#h.qobmda543waj) locale data with various additions and corrections. These are maintenance releases for ICU 73 and CLDR 43, with limited sets of bug fixes and no API or structural changes.

There are significant changes for [GB18030-2022](https://ken-lunde.medium.com/the-gb-18030-2022-standard-3d0ebaeb4132) compliance support:
- CLDR extends the support for “short” Chinese sort orders to cover some additional, required characters for Level 2. This is carried over into ICU collation.
- ICU has a modified character conversion table, mapping some GB18030 characters to Unicode characters that were encoded after GB18030-2005.

There are also changes for compatibility:
- There are optional variants of time formats with AM/PM (only for English) using ASCII spaces in CLDR that can also be used in ICU via custom data generation. This is intended to help certain implementers transition to the improved patterns, which have used a narrow no-break space between the time and AM/PM since [CLDR 42](https://cldr.unicode.org/index/downloads/cldr-42#h.ck7cpcrqqrq0).
  - For how to generate ICU data with this option, look for alt="ascii" on[ main/tools/cldr/cldr-to-icu/README.md](https://github.com/unicode-org/icu/blob/main/tools/cldr/cldr-to-icu/README.md)
- The changes to the word segmentation behavior of @ sign that were in CLDR 42 (ICU 72) have been reverted. These caused problems for certain parsers that did not expect @ to join to letters.

ICU 73.2 and CLDR 43.1 include several other bug fixes, including person name formatting, and Cyrillic transforms.

For details, please see https://icu.unicode.org/download/73.

*Note: The prebuilt WinARM64 binaries below should be considered alpha/experimental.*
</blockquote>

*I am a bot, and this action was performed automatically.*