### PR TITLE
[autoupdate] Update ICU from "ICU 73.2" to "ICU 74.1"

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -10,9 +10,9 @@ set -euxo pipefail
 # in actions/updatelib.py.
 
 # START DEPENDENCY-AUTOUPDATE SECTION
-ICU_NAME="ICU 73.2"
-ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-Win64-MSVC2019.zip
-ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-src.tgz
+ICU_NAME="ICU 74.1"
+ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-74-1/icu4c-74_1-Win64-MSVC2022.zip
+ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-74-1/icu4c-74_1-src.tgz
 JSON_VERSION=3.11.2
 JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip
 PYVERSIONS_WIN="3.7.9 3.8.10 3.9.13 3.10.11 3.11.6 3.12.0"


### PR DESCRIPTION
As of 2023-10-27T23:28:23Z, a new version of ICU has been released.

Release Information (sourced from https://github.com/unicode-org/icu/releases/tag/release-74-1)
<blockquote>

Unicode® ICU 74 updates to [Unicode 15.1](http://blog.unicode.org/2023/09/announcing-unicode-standard-version-151.html), and to [CLDR 44](https://cldr.unicode.org/index/downloads/cldr-44) locale data with various additions and corrections.

ICU 74 and CLDR 44 are major releases, including a new version of Unicode and major locale data improvements. They subsume the changes for the [ICU 73.2 and CLDR 43.1 maintenance releases](https://blog.unicode.org/2023/06/icu-732-cldr-431-released-gb18030.html).

Unicode 15.1 adds source code security mechanisms, improves line breaking for southeast Asian scripts, and adds important CJK unified ideographs.

CLDR 44 has added or improved data for a number of languages that have been newly added to ICU, and has improved measurement unit handling, conversion, and formatting.

ICU 74 implements these improvements, adds new C APIs for locale handling, adds a plug-in API for word segmentation, and switches the Java build system to Maven.

For details, please see https://icu.unicode.org/download/74.
</blockquote>

*I am a bot, and this action was performed automatically.*