### PR TITLE
[autoupdate] Update JSON for Modern C++ from "3.11.2" to "3.11.3"

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -13,8 +13,8 @@ set -euxo pipefail
 ICU_NAME="ICU 74.1"
 ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-74-1/icu4c-74_1-Win64-MSVC2022.zip
 ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-74-1/icu4c-74_1-src.tgz
-JSON_VERSION=3.11.2
-JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip
+JSON_VERSION=3.11.3
+JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip
 PYVERSIONS_WIN="3.7.9 3.8.10 3.9.13 3.10.11 3.11.6 3.12.0"
 PYVERSIONS_MACOSUNIVERSAL="3.8.10 3.9.13 3.10.11 3.11.6 3.12.0"
 PYURLS_MACOSUNIVERSAL="https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg https://www.python.org/ftp/python/3.10.11/python-3.10.11-macos11.pkg https://www.python.org/ftp/python/3.11.6/python-3.11.6-macos11.pkg https://www.python.org/ftp/python/3.12.0/python-3.12.0-macos11.pkg"


### PR DESCRIPTION
As of 2023-11-28T21:38:09Z, a new version of JSON for Modern C++ has been released.

Release Information (sourced from https://github.com/nlohmann/json/releases/tag/v3.11.3)
<blockquote>

Release date: 2023-11-28
SHA-256: 9bea4c8066ef4a1c206b2be5a36302f8926f7fdc6087af5d20b417d0cf103ea6 (json.hpp), a22461d13119ac5c78f205d3df1db13403e58ce1bb1794edc9313677313f4a9d (include.zip), d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d (json.tar.xz)

### Summary

This release fixes some bugs found in the [3.11.2](https://github.com/nlohmann/json/releases/tag/v3.11.2) release.

All changes are backward-compatible.

:moneybag: Note you can **support this project** via [GitHub sponsors](https://github.com/sponsors/nlohmann) or [PayPal](https://paypal.me/nlohmann).

### :sparkles: New Features

- Allow [**custom base class**](https://json.nlohmann.me/api/basic_json/json_base_class_t/) as node customization point. This adds an additional template parameter which allows to set a custom base class for `nlohmann::json`. This class serves as an extension point and allows to add functionality to json node. Examples for such functionality might be metadata or additional member functions (e.g., visitors) or other application specific code. By default the parameter is set to `void` and an empty base class is used. In this case the library behaves as it already did. #3110
- Add more specific parse error message when attempting to **parse empty input**. #4037 #4180
- Add serialization-only user defined type [**macros**](https://json.nlohmann.me/features/macros/) (`NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_ONLY_SERIALIZE` and `NLOHMANN_DEFINE_TYPE_INTRUSIVE_ONLY_SERIALIZE`). #3816
- Add **Bazel** build support. If you are using [Bazel](https://bazel.build/) you can simply reference this repository using `http_archive` or `git_repository` and depend on `@nlohmann_json//:json`. #3709
- Support Apple's Swift Package Manager. #4010

### :bug: Bug Fixes

- Adjust CMake files to accept `NEW` **CMake policies** up to CMake 3.14. This fixes a nasty deprecation warning that "Compatibility with CMake < 3.5 will be removed from a future version of CMake". #4076 #4112
- Fix CMake header path in install with custom `CMAKE_INSTALL_INCLUDEDIR`. #4194
- Add missing `<numeric>` header include. #3717 #3718 #3719
- Replace uses of `INT_MIN`/`INT_MAX`, etc. with `std::numeric_limits` and consistently use `std`-namespaced integer types to make library work with never GCC versions. #3722 #3723
- Add missing files (`json_fwd.hpp` and Bazel build files) to release artifact `include.zip`. #3727 #3728
- Fix 'declaration hides global declaration' warning. #3751
- Fix natvis XML. #3858 #3863
- Fix warning about moved from object. #3805 #3889
- Remove a magic number to fix a warning. #3837 #3888
- Fix debug pretty-printer by checking if match is valid before accessing group. #3919 #3920
- Fix custom allocators by defining missing `rebind` type. #3895 #3927
- Prevent memory leak when exception is thrown in `adl_serializer::to_json` #3881 #3901
- Fix Clang-Tidy warnings. #4047
- Fix init-list construction when `size_type` is not `int`. #4140
- Fix deprecation warning "identifier `_json` preceded by whitespace in a literal operator declaration". #4129 #4161
- Fix compile error with `_HAS_STATIC_RTTI=0`. #4046
- Fix char_traits deprecation warning "`char_traits<unsigned char>` is deprecated: `char_traits<T>` for `T` not equal to `char`, `wchar_t`, `char8_t`, `char16_t` or `char32_t` is non-standard". #4163 #4179

### :hammer: Further Changes

#### CI

- Use official [Clang](https://github.com/silkeh/docker-clang)/[GCC](https://hub.docker.com/_/gcc) Docker containers in the CI. #3703
- Add workflow to check if the source files area amalgamated. #3693
- Fix CI build. #3724 #3862 #3978 #3985 #4025 #4083 #4160 #4196 #4215
- Use Clang 15. #3822 #3876
- Add [CIFuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration/) CI GitHub action. #3845
- Fix MinGW script and CI. #3892 #4175
- Removed lgtm and DroneCI and added [Cirrus CI](https://cirrus-ci.org). #3890 #3906 #3935 #3937
- Set minimal permissions to Github Workflows. #3971 #3972
- Refactor amalgamation workflow to avoid dangerous use of pull_request_target. #3945 #3969

#### Documentation

- Add [**migration guide**](https://json.nlohmann.me/integration/migration_guide/) to replace deprecated library functions. #3702 #3887
- Add dark mode toggle to documentation #3726
- Fix typos in documentation. #3748 #3767 #3902 #3932 #3951 #4109 #4126 #4143 #4149 #4159 #4173
- Update Codacy link. #3740
- Bump documentation tool versions. #3781 #3872 #3891 #3934
- Add vcpkg port version badge. #3988
- Add to `CONTRIBUTING.md` that `make pretty` is required for test updates. #4045
- Use template get instead of get in examples. #3827 #4038 #4039
- Capture exceptions by `const&` in docs. #4099
- Fix source highlighting in user defined type macros docs. #4169

#### Tests

- Use `std::ranges::equals` for range comparisons in test case. #3927 #3950
- Add more algorithm tests to `unit-algorithm.cpp`. #4044

### :fire: Deprecated functions

This release does not deprecate any function. See the [**migration guide**](https://json.nlohmann.me/integration/migration_guide/) for help adjusting your code for future versions.

The following functions have been deprecated in earlier versions and will be removed in the next major version (i.e., 4.0.0):

- The function `iterator_wrapper` is deprecated. Please use the member function [`items()`](https://json.nlohmann.me/api/basic_json/items/) instead.
- Functions `friend std::istream& operator<<(basic_json&, std::istream&)` and `friend std::ostream& operator>>(const basic_json&, std::ostream&)` are deprecated. Please use [`friend std::istream&  operator>>(std::istream&, basic_json&)`](https://json.nlohmann.me/api/operator_gtgt/) and [`friend operator<<(std::ostream&, const basic_json&)`](https://json.nlohmann.me/api/operator_ltlt/) instead.
- Passing iterator pairs or pointer/length pairs to parsing functions (`basic_json::parse`, `basic_json::accept`, `basic_json::sax_parse`, `basic_json::from_cbor`, `basic_json::from_msgpack`, `basic_json::from_ubjson`, `basic_json::from_bson`) via initializer lists is deprecated. Instead, pass two iterators; for instance, call `basic_json::from_cbor(ptr, ptr+len)` instead of `basic_json::from_cbor({ptr, len})`.
- The implicit conversion from JSON Pointers to string ([`json_pointer::operator string_t`](https://json.nlohmann.me/api/json_pointer/operator_string_t)) is deprecated. Use [`json_pointer::to_string`](https://json.nlohmann.me/api/json_pointer/to_string/) instead.
- Comparing JSON Pointers with strings via [`operator==`](https://json.nlohmann.me/api/json_pointer/operator_eq/) and [`operator!=`](https://json.nlohmann.me/api/json_pointer/operator_ne/) have been deprecated. To compare a [`json_pointer`](https://json.nlohmann.me/api/json_pointer/) `p` with a string `s`, convert `s` to a `json_pointer` first and use [`json_pointer::operator==`](https://json.nlohmann.me/api/json_pointer/operator_eq/) or [`json_pointer::operator!=`](https://json.nlohmann.me/api/json_pointer/operator_ne/). #3684

All deprecations are annotated with [`HEDLEY_DEPRECATED_FOR`](https://nemequ.github.io/hedley/api-reference.html#HEDLEY_DEPRECATED_FOR) to report which function to use instead.

</blockquote>

*I am a bot, and this action was performed automatically.*