### PR TITLE
[autoupdate] Update ICU from "ICU 74.1" to "ICU 74.2"

### DIFF
--- a/actions/dependencies.sh
+++ b/actions/dependencies.sh
@@ -10,9 +10,9 @@ set -euxo pipefail
 # in actions/updatelib.py.
 
 # START DEPENDENCY-AUTOUPDATE SECTION
-ICU_NAME="ICU 74.1"
-ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-74-1/icu4c-74_1-Win64-MSVC2022.zip
-ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-74-1/icu4c-74_1-src.tgz
+ICU_NAME="ICU 74.2"
+ICU_URL_WIN=https://github.com/unicode-org/icu/releases/download/release-74-2/icu4c-74_2-Win64-MSVC2019.zip
+ICU_URL_SRC=https://github.com/unicode-org/icu/releases/download/release-74-2/icu4c-74_2-src.tgz
 JSON_VERSION=3.11.3
 JSON_URL=https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip
 PYVERSIONS_WIN="3.7.9 3.8.10 3.9.13 3.10.11 3.11.7 3.12.1"


### PR DESCRIPTION
As of 2023-12-11T19:06:58Z, a new version of ICU has been released.

Release Information (sourced from https://github.com/unicode-org/icu/releases/tag/release-74-2)
<blockquote>

ICU 74.2 updates to [CLDR 44.1](https://cldr.unicode.org/index/downloads/cldr-44#h.nvqx283jwsx) locale data. These are maintenance releases for ICU 74 and CLDR 44, with limited sets of bug fixes and no API or structural changes.
- The CLDR bug fix relevant for ICU is for some formatting patterns that erroneously had two adjacent space characters. These are coalesced into one. ([CLDR-17233](https://unicode-org.atlassian.net/browse/CLDR-17233))
- Important: DateFormat.getInstanceForSkeleton() and the DateTimePatternGenerator sometimes used the wrong patterns because they failed to use/inherit certain data ([ICU-22575](https://unicode-org.atlassian.net/browse/ICU-22575) — CLDR 44 had removed some redundant data that ICU relied on)

For details, please see https://icu.unicode.org/download/74.
</blockquote>

*I am a bot, and this action was performed automatically.*